### PR TITLE
Fix pkger install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH=
-FROM ${ARCH}golang:1.16-alpine3.13 AS build
+FROM ${ARCH}golang:1.18-alpine3.15 AS build
 
 RUN apk --no-cache add \
     bash \
@@ -12,11 +12,11 @@ ENV CGO_ENABLED=0
 COPY . /build
 WORKDIR /build
 
-RUN go get github.com/markbates/pkger/cmd/pkger && \
+RUN go install github.com/markbates/pkger/cmd/pkger@latest && \
     pkger -include /data/words.json && \
     go build .
 
-FROM ${ARCH}alpine:3.13 AS deploy
+FROM ${ARCH}alpine:3.15 AS deploy
 
 WORKDIR /
 COPY --from=build /build/wordchain /

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Development
 
 ```shell
-$ go get github.com/markbates/pkger/cmd/pkger
+$ go install github.com/markbates/pkger/cmd/pkger@latest
 $ pkger -include /data/words.json
 # Install go-swagger
 # https://goswagger.io/install.html


### PR DESCRIPTION
This updates the way `pkger` is installed in the container image, so that it worked properly with newer versions of Go.